### PR TITLE
hawkbit: change default port number to 8080

### DIFF
--- a/src/hawkbit.h
+++ b/src/hawkbit.h
@@ -17,7 +17,7 @@
 
 #define HAWKBIT_HOST	"gitci.com:8080"
 #define HAWKBIT_IPADDR	"fc00::d4e7:0:0:1"
-#define HAWKBIT_PORT	8888
+#define HAWKBIT_PORT	8080
 #define HAWKBIT_JSON_URL "/DEFAULT/controller/v1"
 
 extern int poll_sleep;


### PR DESCRIPTION
Same as the public port used when not using tinyproxy.

Image https://builds.96boards.org/snapshots/reference-platform/debian-iot/24/hikey/ contains the tinyproxy config change.