### PR TITLE
bt/6lowpan: use local peer ipv6 address for gateway

### DIFF
--- a/src/hawkbit.h
+++ b/src/hawkbit.h
@@ -5,7 +5,7 @@
  */
 
 #define HAWKBIT_HOST	"gitci.com:8080"
-#define HAWKBIT_IPADDR	"fc00::d4e7:0:0:1"
+#define HAWKBIT_IPADDR	"fe80::d4e7:0:0:1"
 #define HAWKBIT_PORT	8080
 #define HAWKBIT_JSON_URL "/DEFAULT/controller/v1"
 


### PR DESCRIPTION
Use the bt0 (gateway bt le 6lowpan interface) local ipv6 address when
connecting to tinyprox.

This change needs to be aligned with a gateway change, as the bt0
address changed to fe80::d4e7:0:0:1/80.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>